### PR TITLE
Paths for views have changed in J4 - Fix Components not completely listed + Fix Frontend / Backend Problem Session scope sessionroot

### DIFF
--- a/fields/quantumuploadimage/media/js/quantummodal.js
+++ b/fields/quantumuploadimage/media/js/quantummodal.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', function () {
         for(let i=0;i<QuantummanagerLists.length;i++) {
             QuantummanagerLists[i].Quantumtoolbar.buttonAdd('insertFileEditor', 'center', 'file-actions', 'btn-insert qm-btn-primary btn-hide', QuantumwindowLang.buttonInsert, 'quantummanager-icon-insert-inverse', {}, function (ev) {
 
-                QuantumUtils.ajaxGet(QuantumUtils.getFullUrl("/administrator/index.php?option=com_quantummanager&task=quantumviewfiles.getParsePath&path=" + encodeURIComponent(pathFile) + '&scope=' + QuantummanagerLists[i].data.scope + '&v=' + QuantumUtils.randomInteger(111111, 999999))).done(function (response) {
+                QuantumUtils.ajaxGet(QuantumUtils.getFullUrl("index.php?option=com_quantummanager&task=quantumviewfiles.getParsePath&path=" + encodeURIComponent(pathFile) + '&scope=' + QuantummanagerLists[i].data.scope + '&v=' + QuantumUtils.randomInteger(111111, 999999))).done(function (response) {
                     response = JSON.parse(response);
 
                     if(response.path !== undefined) {


### PR DESCRIPTION
1. The path could not be resolved correctly for scope sessionroot because of the missing session variable with different sessions in Frontend and Backend. This fixes the false resolveing of the path.
2. Bugfix for Joomla 4.x - The relevant components are not listed in select-field in plugin quantummanagermedia - paths for views have changed in J4